### PR TITLE
removed hard dependency to bootstrap css

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import 'bootstrap/dist/css/bootstrap.min.css';
+// import 'bootstrap/dist/css/bootstrap.min.css';
 
 export * from './FormikControl';
 export * from './FormikCheck';


### PR DESCRIPTION
because currently bootstrap.css is imported by this component, this will prevent from using a custom boostrap.css. In my current project I'm using the boostrap scss-modules, to create my own branded bootstrap-css, but because of this import the OOTB bootstrap will be imported and added to app. This will override my custom styles.

So I think it would be better to **not** import the css, but rather leave this to the user to import the css.